### PR TITLE
`Feature` Support for UNIX-sockets

### DIFF
--- a/kbactiond/config.c
+++ b/kbactiond/config.c
@@ -1,3 +1,6 @@
+#include <string.h>
+#include <stdlib.h>
+
 bool cfg_parse_connspec(CONN_SPEC* spec, char* input){
 	unsigned off;
 
@@ -8,6 +11,19 @@ bool cfg_parse_connspec(CONN_SPEC* spec, char* input){
 		return false;
 	}
 
+	if (!strncmp(input, "unix://", 7)) {
+		// parse unix-socket
+		off -= 7;
+		spec->hostname=calloc(off + 1, sizeof(char));
+		if(!spec->hostname){
+			return false;
+		}
+		strncpy(spec->hostname, input + 7, off);
+		spec->socket_type = UNIX_SOCKET;
+		return true;
+	}
+
+	// parse tcp-socket
 	spec->hostname=calloc(off+1, sizeof(char));
 	if(!spec->hostname){
 		return false;
@@ -20,6 +36,7 @@ bool cfg_parse_connspec(CONN_SPEC* spec, char* input){
 	if(spec->port==0){
 		return false;
 	}
+	spec->socket_type = TCP_SOCKET;
 
 	return true;
 }

--- a/kbactiond/controller.conf
+++ b/kbactiond/controller.conf
@@ -3,6 +3,8 @@ listen 127.0.0.1 8127
 connect 127.0.0.1 8126
 #connect ::1 8128
 #connect ::1 8129
+# listen unix://server-listen.sock
+# connect unix://server.sock
 timeout 60
 
 	#START		new command, remove old buffer

--- a/kbactiond/kbactiond.h
+++ b/kbactiond/kbactiond.h
@@ -29,9 +29,15 @@ typedef enum /*_TTYPE*/ {
 	T_EXEC
 } TOKEN_TYPE;
 
+typedef enum {
+	TCP_SOCKET,
+	UNIX_SOCKET
+} SOCKET_TYPE;
+
 typedef struct /*_CONNSPEC*/ {
 	char* hostname;
 	uint16_t port;
+	SOCKET_TYPE socket_type;
 } CONN_SPEC;
 
 typedef struct /*_CONN*/{

--- a/kbactiond/sockfd.c
+++ b/kbactiond/sockfd.c
@@ -1,3 +1,6 @@
+#include <sys/socket.h>
+#include <sys/un.h>
+
 int conn_handle_read(ARGUMENTS* args, CONFIG* cfg, unsigned connection){
 	int bytes, bytes_left;
 
@@ -159,7 +162,7 @@ int conn_process_blocking(ARGUMENTS* args, CONFIG* cfg){
 	return 0;
 }
 
-bool conn_open(CONNECTION* conn){
+bool conn_open_tcp(CONNECTION* conn){
 	int status;
 	char port[10];
 
@@ -188,7 +191,7 @@ bool conn_open(CONNECTION* conn){
 
 	for(list_it=list;list_it!=NULL;list_it=list_it->ai_next){
 		conn->fd=socket(list_it->ai_family, list_it->ai_socktype, list_it->ai_protocol);
-		
+
 		if(conn->fd<0){
 			continue;
 		}
@@ -225,12 +228,72 @@ bool conn_open(CONNECTION* conn){
 	}
 
 	freeaddrinfo(list);
-	
+
 	if(!list_it){
 		return false;
 	}
-	
+
 	return true;
+}
+
+bool conn_open_unix(CONNECTION* conn){
+	int status;
+
+	struct sockaddr_un addr;
+
+
+	if(conn->type!=CONN_LISTEN&&conn->type!=CONN_OUTGOING){
+		return false;
+	}
+
+	if ((conn->fd = socket(PF_UNIX, SOCK_STREAM, 0)) < 0) {
+		fprintf(stderr, "Could not create UNIX-socket!\n");
+		return -1;
+	}
+
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strcpy(addr.sun_path, conn->spec.hostname);
+
+	if(conn->type==CONN_LISTEN){
+		unlink(conn->spec.hostname);
+
+		if (bind(conn->fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+			fprintf(stderr, "Could not bind to socket!\n");
+			close(conn->fd);
+			conn->fd=-1;
+			return false;
+		}
+
+		status=listen(conn->fd, LISTEN_QUEUE_LENGTH);
+		if (status<0){
+			perror("conn_open/listen");
+			close(conn->fd);
+			conn->fd=-1;
+			return false;
+		}
+
+	}
+	else if(conn->type==CONN_OUTGOING){
+		if (connect(conn->fd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+			perror("conn_open/connect");
+			close(conn->fd);
+			conn->fd=-1;
+			return -1;
+		}
+	}
+
+	return true;
+}
+
+
+bool conn_open(CONNECTION* conn){
+	if (conn->spec.socket_type == TCP_SOCKET) {
+		return conn_open_tcp(conn);
+	} else {
+		return conn_open_unix(conn);
+	}
 }
 
 bool conn_reconnect(ARGUMENTS* args, CONFIG* cfg){
@@ -263,10 +326,18 @@ bool conn_init(ARGUMENTS* args, CONFIG* cfg){
 	if(cfg->listen_socks){
 		for(pos=0;cfg->listen_socks[pos];pos++){
 			if(args->verbosity>1){
-				fprintf(stderr, "Opening listening socket on %s Port %d\n", cfg->listen_socks[pos]->spec.hostname, cfg->listen_socks[pos]->spec.port);
+				if (cfg->listen_socks[pos]->spec.socket_type == TCP_SOCKET) {
+					fprintf(stderr, "Opening listening socket on %s Port %d\n", cfg->listen_socks[pos]->spec.hostname, cfg->listen_socks[pos]->spec.port);
+				} else {
+					fprintf(stderr, "Opening listening unix-socket on %s\n", cfg->listen_socks[pos]->spec.hostname);
+				}
 			}
 			if(!conn_open(cfg->listen_socks[pos])){
-				fprintf(stderr, "Failed to open listening socket on %s Port %d\n", cfg->listen_socks[pos]->spec.hostname, cfg->listen_socks[pos]->spec.port);
+				if (cfg->listen_socks[pos]->spec.socket_type == TCP_SOCKET) {
+					fprintf(stderr, "Failed to open listening socket on %s Port %d\n", cfg->listen_socks[pos]->spec.hostname, cfg->listen_socks[pos]->spec.port);
+				} else {
+					fprintf(stderr, "Failed to open listening unix-socket on %s\n", cfg->listen_socks[pos]->spec.hostname);
+				}
 				return false;
 			}
 		}
@@ -277,11 +348,21 @@ bool conn_init(ARGUMENTS* args, CONFIG* cfg){
 		for(pos=0;cfg->inputs[pos];pos++){
 			if(cfg->inputs[pos]->conn.type==CONN_OUTGOING){
 				if(args->verbosity>1){
-					fprintf(stderr, "Opening connection to %s Port %d\n", cfg->inputs[pos]->conn.spec.hostname, cfg->inputs[pos]->conn.spec.port);
+					if (cfg->listen_socks[pos]->spec.socket_type == TCP_SOCKET) {
+						fprintf(stderr, "Opening connection to %s Port %d\n", cfg->inputs[pos]->conn.spec.hostname, cfg->inputs[pos]->conn.spec.port);
+					} else {
+						fprintf(stderr, "Opening unix-socket on %s\n", cfg->inputs[pos]->conn.spec.hostname);
+					}
+
 				}
 
 				if(!conn_open(&(cfg->inputs[pos]->conn))){
-					fprintf(stderr, "Failed to connect to %s Port %d\n", cfg->inputs[pos]->conn.spec.hostname, cfg->inputs[pos]->conn.spec.port);
+					if (cfg->listen_socks[pos]->spec.socket_type == TCP_SOCKET) {
+						fprintf(stderr, "Failed to connect to %s Port %d\n", cfg->inputs[pos]->conn.spec.hostname, cfg->inputs[pos]->conn.spec.port);
+					} else {
+						fprintf(stderr, "Failed to open unix-socket on %s\n", cfg->inputs[pos]->conn.spec.hostname);
+					}
+
 					return false;
 				}
 

--- a/kbactiond/sockfd.c
+++ b/kbactiond/sockfd.c
@@ -348,7 +348,7 @@ bool conn_init(ARGUMENTS* args, CONFIG* cfg){
 		for(pos=0;cfg->inputs[pos];pos++){
 			if(cfg->inputs[pos]->conn.type==CONN_OUTGOING){
 				if(args->verbosity>1){
-					if (cfg->listen_socks[pos]->spec.socket_type == TCP_SOCKET) {
+					if (cfg->inputs[pos]->conn.spec.socket_type == TCP_SOCKET) {
 						fprintf(stderr, "Opening connection to %s Port %d\n", cfg->inputs[pos]->conn.spec.hostname, cfg->inputs[pos]->conn.spec.port);
 					} else {
 						fprintf(stderr, "Opening unix-socket on %s\n", cfg->inputs[pos]->conn.spec.hostname);
@@ -357,7 +357,7 @@ bool conn_init(ARGUMENTS* args, CONFIG* cfg){
 				}
 
 				if(!conn_open(&(cfg->inputs[pos]->conn))){
-					if (cfg->listen_socks[pos]->spec.socket_type == TCP_SOCKET) {
+					if (cfg->inputs[pos]->conn.spec.socket_type == TCP_SOCKET) {
 						fprintf(stderr, "Failed to connect to %s Port %d\n", cfg->inputs[pos]->conn.spec.hostname, cfg->inputs[pos]->conn.spec.port);
 					} else {
 						fprintf(stderr, "Failed to open unix-socket on %s\n", cfg->inputs[pos]->conn.spec.hostname);

--- a/kbserver/cfgparse.c
+++ b/kbserver/cfgparse.c
@@ -111,6 +111,18 @@ int parse_config(char* input_file, CONFIG_PARAMS* cfg){
 				continue;
 			}
 		}
+		else if(!strncmp(line_buffer+offset, "socket_type", 11)){
+			//handle socket_type line
+			if(!strncmp(line_buffer+param, "unix", 4)){
+				cfg->socket_type=UNIX_SOCKET;
+			} else {
+				cfg->socket_type=TCP_SOCKET;
+			}
+		}
+		else if(!strncmp(line_buffer+offset, "socket_file", 11)){
+			cfg->unix_socket_location=calloc(strlen(line_buffer+param)+1, sizeof(char));
+			strncpy(cfg->unix_socket_location, line_buffer+param, strlen(line_buffer+param));
+		}
 		else{
 			fprintf(stderr, "Unrecognized config line: %s\n",line_buffer+offset);
 		}

--- a/kbserver/kbserver.h
+++ b/kbserver/kbserver.h
@@ -8,6 +8,11 @@ typedef enum /*_KEYMODE*/ {
 	MODE_DOWN=1
 } KEYMODE;
 
+typedef enum {
+	TCP_SOCKET,
+	UNIX_SOCKET
+} SOCKET_TYPE;
+
 typedef struct _MAPPING {
 	uint16_t scancode;
 	KEYMODE mode;
@@ -20,8 +25,10 @@ typedef struct /*_CFG_PARAMS*/ {
 	char* config_file;	//cfg file, allocated by system
 	MAPPING* mapping_head;
 	char* input_device;	//input device, allocated by cfgparse
+	SOCKET_TYPE socket_type;   // the type of the listening-socket
 	char* bind_host;	//bindhost, allocated by cfgparse
 	uint16_t port;		//local port
+	char* unix_socket_location;	// the location of the unix-socket to use
 	bool send_raw;		//send raw scancodes
 	bool exclusive_access;	//request exclusive access
 } CONFIG_PARAMS;

--- a/kbserver/local-kbd.conf
+++ b/kbserver/local-kbd.conf
@@ -2,6 +2,9 @@
 device /dev/input/by-id/usb-Cherry_GmbH_0001-event-kbd
 bind 127.0.0.1
 port 8123
+socket_type tcp
+# socket_type unix
+# socket_file server.sock
 send_raw false
 exclusive true
 

--- a/kbserver/sockfd.c
+++ b/kbserver/sockfd.c
@@ -1,4 +1,12 @@
-int sock_open(CONFIG_PARAMS* cfg){
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+int sock_open_tcp(CONFIG_PARAMS* cfg){
 	int fd=-1, status;
 	char port[10];
 	struct addrinfo hints;
@@ -37,6 +45,9 @@ int sock_open(CONFIG_PARAMS* cfg){
 
 	if(!addr_it){
 		fprintf(stderr, "Failed to create listening socket\n");
+		if (fd >= 0) {
+			close(fd);
+		}
 		return -1;
 	}
 
@@ -48,6 +59,46 @@ int sock_open(CONFIG_PARAMS* cfg){
 	}
 
 	return fd;
+}
+
+int sock_open_unix(CONFIG_PARAMS* cfg){
+	int fd;
+	struct sockaddr_un addr;
+
+	if ((fd = socket(PF_UNIX, SOCK_STREAM, 0)) < 0) {
+		fprintf(stderr, "Could not create UNIX-socket!\n");
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strcpy(addr.sun_path, cfg->unix_socket_location);
+	unlink(cfg->unix_socket_location);
+
+	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		fprintf(stderr, "Could not bind to socket!\n");
+		if (fd >= 0) {
+			close(fd);
+		}
+		return -1;
+	}
+
+	int status=listen(fd, LISTEN_QUEUE_LENGTH);
+	if(status<0){
+		perror("sock_open/listen");
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+int sock_open(CONFIG_PARAMS* cfg) {
+	if (cfg->socket_type == TCP_SOCKET) {
+		return sock_open_tcp(cfg);
+	} else {
+		return sock_open_unix(cfg);
+	}
 }
 
 int sock_close(int fd){


### PR DESCRIPTION
I've implemented some basic support for unix-sockets instead of TCP as we consider moving towards those at FSMI.

I've updated the sample-configuration files in the repository to show the additional configuration-syntax. Both configurations are also able to handle absolute paths (even though `unix:///home/...` might seem a little odd :D)

*Note: A single instance of kbserver can (currently) only support **either** TCP or UNIX-sockets!*

Feel free to add suggestions.